### PR TITLE
Make backend configurable with envvars

### DIFF
--- a/backend/metrics_backend/metrics_service.py
+++ b/backend/metrics_backend/metrics_service.py
@@ -71,7 +71,10 @@ class MetricsService(gevent.Greenlet):
             sync_start_block=sync_start_block,
             required_confirmations=self.required_confirmations,
         )
-        log.info(f'Listening to token network registry @ {registry_address}')
+        log.info(
+            f'Listening to token network registry @ {registry_address} '
+            f'from block {sync_start_block}'
+        )
         self._setup_token_networks()
 
     def _setup_token_networks(self):

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,8 @@ version: '3'
 services:
   frontend:
     image: frontend
-    build: ./frontend
+    build:
+      context: ./frontend
     restart: always
     labels:
       - "traefik.enable=true"
@@ -12,8 +13,13 @@ services:
 
   backend:
     image: backend
-    build: ./backend
+    build:
+      context: ./backend
     restart: always
+    environment:
+      - EXPLORER_ETH_RPC=http://geth.ropsten.ethnodes.brainbot.com:8545
+      - EXPLORER_REGISTRY_ADDRESS=0xf2a175A52Bd3c815eD7500c765bA19652AB89B30
+      - EXPLORER_START_BLOCK=3800000
     labels:
       - "traefik.enable=true"
       - "traefik.frontend.rule=Host:explorer.raiden.network; Path: /json"


### PR DESCRIPTION
This will make it easier to run ropsten and mainnet backends in the
future.
This also updates the docker-compose setup to make use of the settings.

Fixes #65