### PR TITLE
Update graph information display

### DIFF
--- a/frontend/src/app/components/network-graph/network-graph.component.ts
+++ b/frontend/src/app/components/network-graph/network-graph.component.ts
@@ -164,7 +164,9 @@ export class NetworkGraphComponent implements OnInit, OnChanges {
         openChannels: value.openChannels,
         closedChannels: value.closedChannels,
         settledChannels: value.settledChannels,
-        tokenAddress: value.tokenAddress
+        tokenAddress: value.tokenAddress,
+        tokenName: value.tokenName,
+        tokenSymbol: value.tokenSymbol
       };
 
       this.graphData.nodes.push(node);
@@ -485,14 +487,30 @@ export class NetworkGraphComponent implements OnInit, OnChanges {
 
 
   private nodeInfo(d: Node): string[] {
-    return [
+    let strings: string[];
+    strings = [
       d.id,
       '',
-      `Token: ${d.tokenAddress}`,
+      `Token`,
+      `Address: ${d.tokenAddress}`
+    ];
+
+    if (d.tokenSymbol) {
+      strings.push(`Symbol: ${d.tokenSymbol}`);
+    }
+
+    if (d.tokenName) {
+      strings.push(`Name: ${d.tokenName}`);
+    }
+
+    strings.push(
+      '',
       `Open Channels: ${d.openChannels}`,
       `Closed Channels: ${d.closedChannels}`,
       `Settled Channels: ${d.settledChannels}`
-    ];
+    );
+
+    return strings;
   }
 
   private clearSelection() {

--- a/frontend/src/app/models/NetworkGraph.ts
+++ b/frontend/src/app/models/NetworkGraph.ts
@@ -12,6 +12,8 @@ export interface Node {
   readonly closedChannels: number;
   readonly settledChannels: number;
   readonly tokenAddress: string;
+  readonly tokenName: string;
+  readonly tokenSymbol: string;
 }
 
 export interface NetworkGraph {

--- a/frontend/src/app/models/NetworkGraph.ts
+++ b/frontend/src/app/models/NetworkGraph.ts
@@ -3,6 +3,7 @@ export interface Link {
   readonly targetAddress: string;
   readonly status: string;
   readonly tokenAddress: string;
+  readonly capacity: number;
 }
 
 export interface Node {

--- a/frontend/src/app/services/net.metrics/net.metrics.service.ts
+++ b/frontend/src/app/services/net.metrics/net.metrics.service.ts
@@ -141,7 +141,9 @@ export class NetMetricsService {
         openChannels,
         closedChannels,
         settledChannels,
-        tokenAddress: network.token.address
+        tokenAddress: network.token.address,
+        tokenName: network.token.name,
+        tokenSymbol: network.token.symbol
       });
     });
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/2269732/46490709-017c8a00-c809-11e8-96c8-83f07cb52a44.png)

![image](https://user-images.githubusercontent.com/2269732/46490741-16f1b400-c809-11e8-9e72-83f9acca571f.png)

Removes the `<title>` based tootlip functionality and replaces it with a custom information box.
Links and nodes are highlighted on `mouseover` and the information box is displayed.
