### PR TITLE
Fixes console error when resizing window.

### DIFF
--- a/frontend/src/app/components/network-graph/network-graph.component.ts
+++ b/frontend/src/app/components/network-graph/network-graph.component.ts
@@ -139,7 +139,7 @@ export class NetworkGraphComponent implements OnInit, OnChanges {
     this.svg.selectAll('.nodes').attr('transform', translation);
     this.svg.selectAll('.links').attr('transform', translation);
     const info = this.svg.selectAll('.info');
-    if (info) {
+    if (!info.empty()) {
       const boxX = parseInt(info.attr('box-x'), 10);
       const boxY = parseInt(info.attr('box-y'), 10);
       const width = boxX + ((this.width - this.initialWidth) / 2);


### PR DESCRIPTION
The selection exists but is empty when the error is thrown, so checking for the `info` being falsey
didn't make sense.

This issue happened at window resize if you didn't have a visible tooltip in the graph.

Closes #89 