### PR TITLE
Filters out networks without open channels

### DIFF
--- a/frontend/src/app/components/home/home.component.css
+++ b/frontend/src/app/components/home/home.component.css
@@ -276,3 +276,9 @@
   height: 68px !important;
 }
 
+.active-networks {
+  font-size: 22px;
+  text-align: center;
+  margin-top: 2rem;
+}
+

--- a/frontend/src/app/components/home/home.component.html
+++ b/frontend/src/app/components/home/home.component.html
@@ -142,6 +142,14 @@
         </div>
       </div>
 
+      <div class="active-networks"
+           fxLayout="row"
+           fxLayoutAlign="center"
+           matTooltip="The networks that have at least one open channel."
+           *ngIf="metrics.totalTokenNetworks > 1">
+        <div class="title">Active Networks</div>
+      </div>
+
       <div fxLayout="row" fxLayoutAlign="center" *ngIf="metrics.totalTokenNetworks > 1">
         <mat-form-field class="search-field"
                         fxLayout="column"
@@ -184,7 +192,6 @@
           </mat-autocomplete>
         </mat-form-field>
       </div>
-
 
       <div class="network-metrics" fxLayout="row" [@flyInOut]="'in'" fxLayoutAlign="center">
         <div fxLayout="column" *ngIf="numberOfNetworks > 1"

--- a/frontend/src/app/components/home/home.component.ts
+++ b/frontend/src/app/components/home/home.component.ts
@@ -53,7 +53,7 @@ export class HomeComponent implements OnInit {
     private overlayContainer: OverlayContainer
   ) {
     this.metrics$ = netMetricsService.metrics$.pipe(tap((metrics) => {
-      this._allNetworks = metrics.tokenNetworks;
+      this._allNetworks = HomeComponent.onlyActive(metrics.tokenNetworks);
       this._loading = false;
 
       if (this._visibleNetworks.length === 0) {
@@ -110,6 +110,10 @@ export class HomeComponent implements OnInit {
 
   public get main(): boolean {
     return this.config.main;
+  }
+
+  private static onlyActive(networks: TokenNetwork[]): TokenNetwork[] {
+    return networks.filter(value => value.openedChannels > 0);
   }
 
   ngOnInit() {
@@ -222,7 +226,7 @@ export class HomeComponent implements OnInit {
   }
 
   private _filter(value?: string): Observable<TokenNetwork[]> {
-    const networks$ = this.metrics$.pipe(map(metrics => metrics.tokenNetworks));
+    const networks$ = this.metrics$.pipe(map(metrics => HomeComponent.onlyActive(metrics.tokenNetworks)));
     if (!value || typeof value !== 'string') {
       return networks$;
     }


### PR DESCRIPTION
I have added a label on the section `Active Networks` and I am filtering the results requiring at least an open channel. 

I am not sure if it would make sense to include some option for people to view all the available token networks or if this would be considered too much.

Closes #71 