### PR TITLE
Get correct contract ABI for older version

### DIFF
--- a/backend/metrics_backend/metrics_cli.py
+++ b/backend/metrics_backend/metrics_cli.py
@@ -138,7 +138,7 @@ def main(
         try:
             service = MetricsService(
                 web3=web3,
-                contract_manager=ContractManager(contracts_precompiled_path()),
+                contract_manager=ContractManager(contracts_precompiled_path(contracts_version)),
                 registry_address=registry_address,
                 sync_start_block=start_block,
                 required_confirmations=confirmations,

--- a/backend/metrics_backend/metrics_service.py
+++ b/backend/metrics_backend/metrics_service.py
@@ -61,7 +61,7 @@ class MetricsService(gevent.Greenlet):
         contract_manager: ContractManager,
         registry_address: Address,
         sync_start_block: int = 0,
-        required_confirmations: int = 8,  # ~2min
+        required_confirmations: int = 5,  # the default
     ) -> None:
         """ Creates a new pathfinding service
 


### PR DESCRIPTION
The problem was that we didn't supply the version of the contracts to `contracts_precompiled_path`, so it loaded the most recent one instead.

Fixes #172 