### PR TITLE
Highlight node by query parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,26 +4,37 @@
 
 ## Running
 
-The Explorer can be run by using `docker-compose`:
+The Explorer can be run by using `docker-compose`. This will build the docker images and run multiple instances of the explorer for mainnet and all supported testnets.
+
 ```sh
 docker-compose build
 docker-compose up -d
 ```
 
-It's important to update the [frontend config files](https://github.com/raiden-network/explorer/tree/master/frontend/src/assets/config) because otherwise the official Explorer backend is used.
-
 ## Frontend
 
-The frontend is built using [Angular](https://angular.io) and required NodeJS. It can be found in the `frontend` directory.
+The frontend is built using [Angular](https://angular.io) and requires NodeJS. It can be found in the `frontend` directory.
 
-To launch a development version of the frontend, install angular globally and run the angular development server:
-```bash
-npm install -g @angular/cli
-cd angular-app
+To launch a development version of the frontend, install the dependencies and run the angular development server:
+
+```sh
+cd frontend
 npm install
-ng serve
+npm start
 ```
+
+It's important to update the [frontend config files](https://github.com/raiden-network/explorer/tree/master/frontend/src/assets/config) because otherwise the official Explorer backend is used.
 
 ## Backend
 
 The backend is written in Python and can be found in the `backend` directory.
+
+To launch a development version of the backend, install the dependencies and run the cli service. Please do so from a virtual environment.
+
+```sh
+cd backend
+make install-dev
+python -m  metrics_backend.metrics_cli
+```
+
+There are a couple of cli options to configure the backend, such as the ethereum node to use. See [metrics_cli.py](backend/metrics_backend/metrics_cli.py) for reference.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12416,9 +12416,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "1.16.4",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.16.4.tgz",
-      "integrity": "sha512-ZzWuos7TI5CKUeQAtFd6Zhm2s6EpAD/ZLApIhsF9pRvRtM1RFo61dM/4MSRUA0SuLugA/zgrZD8m0BaY46Og7g==",
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
+      "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
       "dev": true
     },
     "process": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -53,7 +53,7 @@
     "karma-coverage-istanbul-reporter": "~3.0.2",
     "karma-jasmine": "~3.3.0",
     "karma-jasmine-html-reporter": "^1.5.0",
-    "prettier": "1.16.4",
+    "prettier": "^1.19.1",
     "protractor": "~7.0.0",
     "ts-node": "~7.0.1",
     "tslint": "~6.1.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,8 +8,8 @@
     "test": "ng test",
     "lint": "ng lint",
     "e2e": "ng e2e",
-    "prettier:fix": "prettier --write \"**/*.*\"",
-    "prettier:check": "prettier --check \"**/*.*\"",
+    "prettier": "prettier --write --config ./.prettierrc './**/*.{ts,tsx,html,css,scss,json,js}'",
+    "prettier:check": "prettier --check --config ./.prettierrc './**/*.{ts,tsx,html,css,scss,json,js}'",
     "postinstall": "ngcc"
   },
   "private": true,

--- a/frontend/src/app/components/active-networks-section/active-networks-section.component.html
+++ b/frontend/src/app/components/active-networks-section/active-networks-section.component.html
@@ -47,7 +47,7 @@
       >
         <mat-option
           class="network-suggestion"
-          *ngFor="let option of (filteredOptions$ | async); trackBy: trackByFn"
+          *ngFor="let option of filteredOptions$ | async; trackBy: trackByFn"
           [value]="option"
         >
           <span class="blocky">

--- a/frontend/src/app/components/buttons-section/buttons-section.component.ts
+++ b/frontend/src/app/components/buttons-section/buttons-section.component.ts
@@ -9,8 +9,4 @@ export class ButtonsSectionComponent implements OnInit {
   constructor() {}
 
   ngOnInit() {}
-
-  scrollToNetwork() {
-    document.querySelector('#network').scrollIntoView();
-  }
 }

--- a/frontend/src/app/components/graph-section/graph-section.component.html
+++ b/frontend/src/app/components/graph-section/graph-section.component.html
@@ -12,9 +12,4 @@
   </a>
 </div>
 
-<app-network-graph
-  id="network-graph"
-  fxLayout="row"
-  fxLayoutAlign="center"
-  [data]="graph"
-></app-network-graph>
+<app-network-graph fxLayout="row" fxLayoutAlign="center" [data]="graph"></app-network-graph>

--- a/frontend/src/app/components/home/home.component.html
+++ b/frontend/src/app/components/home/home.component.html
@@ -2,7 +2,7 @@
   <mat-spinner></mat-spinner>
 </div>
 
-<div *ngIf="(metrics$ | async) as metrics; else error">
+<div *ngIf="metrics$ | async as metrics; else error">
   <app-network-totals [network]="network" [metrics]="metrics"></app-network-totals>
 
   <app-active-networks-section
@@ -21,12 +21,7 @@
 
 <ng-template #error>
   <div class="warning-wrapper" [@flyInOut]="'in'">
-    <div
-      class="warning-div"
-      fxLayout="column"
-      fxFlex="0 0 60"
-      *ngIf="(messages$ | async) as message"
-    >
+    <div class="warning-div" fxLayout="column" fxFlex="0 0 60" *ngIf="messages$ | async as message">
       <h2 fxLayout="row">{{ message.title }}</h2>
       <p fxLayout="row">{{ message.description }}</p>
     </div>

--- a/frontend/src/app/components/network-graph/network-graph.component.html
+++ b/frontend/src/app/components/network-graph/network-graph.component.html
@@ -1,4 +1,4 @@
-<div class="graph" fxLayout="column">
+<div class="graph" id="network-graph" fxLayout="column">
   <div
     fxLayout.gt-xs="row"
     fxLayout="column"
@@ -20,11 +20,11 @@
         />
         <button
           mat-button
-          *ngIf="filterControl.value"
           matSuffix
           mat-icon-button
           aria-label="Clear"
           (click)="clearFilter()"
+          [style.visibility]="filterControl.value ? 'visible' : 'hidden'"
         >
           <img src="../../../assets/baseline-clear-24px.svg" />
         </button>

--- a/frontend/src/app/components/network-graph/network-graph.component.html
+++ b/frontend/src/app/components/network-graph/network-graph.component.html
@@ -36,7 +36,7 @@
         >
           <mat-option
             class="element-suggestion"
-            *ngFor="let option of (filteredOptions$ | async); trackBy: trackByFn"
+            *ngFor="let option of filteredOptions$ | async; trackBy: trackByFn"
             [value]="option"
           >
             <span class="blocky" *ngIf="isNode(option); else channel">

--- a/frontend/src/app/components/network-graph/network-graph.component.ts
+++ b/frontend/src/app/components/network-graph/network-graph.component.ts
@@ -97,8 +97,8 @@ export class NetworkGraphComponent implements OnInit, OnChanges, OnDestroy, Afte
   };
   private tokenNetworks: string[];
   private nodeColor: d3.ScaleOrdinal<string, any>;
-  private highlightedLink: SimulationLink;
-  private highlightedNode: SimulationNode;
+  private selectedLink: SimulationLink;
+  private selectedNode: SimulationNode;
 
   private nextKey = 0;
   private keyToDatum = {};
@@ -697,19 +697,18 @@ export class NetworkGraphComponent implements OnInit, OnChanges, OnDestroy, Afte
       .text((d: string) => d);
   }
 
-  private selectLink(datum: SimulationLink) {
-    this.highlightLink(datum);
-    this.highlightedLink = datum;
+  private selectLink(link: SimulationLink) {
+    this.highlightLink(link);
+    this.selectedLink = link;
     this.drawLinkInfoBox();
   }
 
   private drawLinkInfoBox() {
-    if (!this.highlightedLink) {
+    if (!this.selectedLink) {
       return;
     }
-    const datum = this.highlightedLink;
-    const source = datum.source as SimulationNodeDatum;
-    const target = datum.target as SimulationNodeDatum;
+    const source = this.selectedLink.source as SimulationNodeDatum;
+    const target = this.selectedLink.target as SimulationNodeDatum;
 
     const x1 = source.x || 0;
     const x2 = target.x || 0;
@@ -717,11 +716,11 @@ export class NetworkGraphComponent implements OnInit, OnChanges, OnDestroy, Afte
     const y2 = target.y || 0;
 
     const data = [
-      this.tooltipLine('Source:', datum.sourceAddress),
-      this.tooltipLine('Target:', datum.targetAddress),
+      this.tooltipLine('Source:', this.selectedLink.sourceAddress),
+      this.tooltipLine('Target:', this.selectedLink.targetAddress),
       this.tooltipLine(
         'Channel capacity:',
-        `${datum.capacity.toFixed((source as Node).token.decimals)} ${
+        `${this.selectedLink.capacity.toFixed((source as Node).token.decimals)} ${
           (source as Node).token.symbol
         }`
       )
@@ -737,17 +736,17 @@ export class NetworkGraphComponent implements OnInit, OnChanges, OnDestroy, Afte
     this.drawInformationBox(boxX, boxY, boxWidth, data);
   }
 
-  private highlightLink(datum: SimulationLink) {
+  private highlightLink(selectedLink: SimulationLink) {
     this.links
       .attr('stroke-opacity', (link: Link) => {
-        if (link === datum) {
+        if (link === selectedLink) {
           return NetworkGraphComponent.NODE_SELECTED_STROKE_OPACITY;
         } else {
           return NetworkGraphComponent.NODE_DEFAULT_STROKE_OPACITY;
         }
       })
       .attr('stroke-width', (link: Link) => {
-        if (link === datum) {
+        if (link === selectedLink) {
           return NetworkGraphComponent.LINK_HIGHLIGHT_STROKE_WIDTH;
         } else {
           return NetworkGraphComponent.LINK_DEFAULT_STROKE_WIDTH;
@@ -843,8 +842,8 @@ export class NetworkGraphComponent implements OnInit, OnChanges, OnDestroy, Afte
   }
 
   private clearSelection() {
-    this.highlightedLink = undefined;
-    this.highlightedNode = undefined;
+    this.selectedLink = undefined;
+    this.selectedNode = undefined;
     this.nodes
       .attr('fill', (datum: Node) => this.nodeColor(datum.token.address))
       .attr('opacity', NetworkGraphComponent.NODE_SELECTED_OPACITY);
@@ -854,30 +853,28 @@ export class NetworkGraphComponent implements OnInit, OnChanges, OnDestroy, Afte
     this.infoBoxOverlay.selectAll('.info').remove();
   }
 
-  private selectNode(selectedNode: SimulationNode) {
-    this.highlightNode(selectedNode);
-    this.highlightedNode = selectedNode;
+  private selectNode(node: SimulationNode) {
+    this.highlightNode(node);
+    this.selectedNode = node;
     this.drawNodeInfoBox();
   }
 
   private drawNodeInfoBox() {
-    if (!this.highlightedNode) {
+    if (!this.selectedNode) {
       return;
     }
-    const selectedNode = this.highlightedNode;
-    const neighbors: Node[] = this.getNeighbors(selectedNode);
-
-    const info = this.nodeInfo(selectedNode);
+    const neighbors: Node[] = this.getNeighbors(this.selectedNode);
+    const info = this.nodeInfo(this.selectedNode);
 
     const boxHeight = info.length * 15 + 10;
     const boxWidth = 320;
 
     const neighborY = (neighbors as SimulationNodeDatum[]).map(value => value.y).sort();
 
-    const boxX = this.getBoxX(selectedNode.x, selectedNode.x, boxWidth);
+    const boxX = this.getBoxX(this.selectedNode.x, this.selectedNode.x, boxWidth);
 
-    const minY = Math.min(selectedNode.y, neighborY[0]);
-    const maxY = Math.max(selectedNode.y, neighborY[neighborY.length - 1]);
+    const minY = Math.min(this.selectedNode.y, neighborY[0]);
+    const maxY = Math.max(this.selectedNode.y, neighborY[neighborY.length - 1]);
     const boxY = this.getBoxY(minY, maxY, 10, boxHeight);
 
     this.drawInformationBox(boxX, boxY, boxWidth, info);

--- a/frontend/src/app/components/network-graph/network-graph.component.ts
+++ b/frontend/src/app/components/network-graph/network-graph.component.ts
@@ -467,7 +467,10 @@ export class NetworkGraphComponent implements OnInit, OnChanges {
 
     this.simulation = d3
       .forceSimulation<SimulationNode, SimulationLink>()
-      .force('link', d3.forceLink().id((node1: SimulationNode) => node1.id + node1.token.address))
+      .force(
+        'link',
+        d3.forceLink().id((node1: SimulationNode) => node1.id + node1.token.address)
+      )
       .force('charge', d3.forceManyBody().distanceMax(180))
       .force('center', d3.forceCenter(this.width / 2, this.height / 2));
 

--- a/frontend/src/app/components/network-graph/network-graph.component.ts
+++ b/frontend/src/app/components/network-graph/network-graph.component.ts
@@ -686,7 +686,9 @@ export class NetworkGraphComponent implements OnInit, OnChanges {
       this.tooltipLine('Target:', datum.targetAddress),
       this.tooltipLine(
         'Channel capacity:',
-        `${datum.capacity.toFixed((source as Node).token.decimals)} tokens`
+        `${datum.capacity.toFixed((source as Node).token.decimals)} ${
+          (source as Node).token.symbol
+        }`
       )
     ];
 

--- a/frontend/src/app/components/network-information/network-information.component.ts
+++ b/frontend/src/app/components/network-information/network-information.component.ts
@@ -59,8 +59,8 @@ export class NetworkInformationComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit(): void {
-    this.subscription = this.route.params
-      .pipe(map(params => params.token_address))
+    this.subscription = this.route.paramMap
+      .pipe(map(params => params.get('token_address')))
       .subscribe(address => {
         const index = +this.sharedService.loadTokenNetworkInformation(address);
         this.routingService.changed(index);

--- a/frontend/src/app/components/open-channel-list/open-channel-list.component.html
+++ b/frontend/src/app/components/open-channel-list/open-channel-list.component.html
@@ -38,9 +38,9 @@
           matTooltip="Capacity {{
             channel.capacity
               | number: '1.' + info.node.token.decimals + '-' + info.node.token.decimals
-          }} tokens"
+          }} {{ info.node.token.symbol }}"
         >
-          Capacity: {{ channel.capacity | smallNumber }} tokens
+          Capacity: {{ channel.capacity | smallNumber }} {{ info.node.token.symbol }}
         </div>
       </mat-list-item>
     </mat-list>

--- a/frontend/src/app/services/net.metrics/net.metrics.service.ts
+++ b/frontend/src/app/services/net.metrics/net.metrics.service.ts
@@ -57,12 +57,7 @@ export class NetMetricsService {
     const networkMetrics = this.http
       .get<NMAPIResponse>(this.nmConfig.configuration.backend_url)
       .pipe(
-        retryWhen(errors =>
-          errors.pipe(
-            delay(this.nmConfig.configuration.poll_interval),
-            take(3)
-          )
-        ),
+        retryWhen(errors => errors.pipe(delay(this.nmConfig.configuration.poll_interval), take(3))),
         share()
       );
 


### PR DESCRIPTION
This PR adds the possibility to highlight a specific node and move the network visualization into the view by providing a query parameter. It looks like this: `https://explorer.raiden.network/tokens/{token_address}?node={node_address}`

This is needed for the connection manager replacement on the WebUI (https://github.com/raiden-network/webui/issues/547). We would like to link to a suggested node in the network visualization from the preview of the PFS partner suggestions.