### PR TITLE
Disable renovate dependency updates for python

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,6 +2,9 @@
   "extends": [
     "config:base"
   ],
+  "python": {
+    "enabled": false
+  },
   "commitMessagePrefix": "dependencies:",
   "packageRules": [
     {


### PR DESCRIPTION
We don't have a CI for the python backend, so we can't automatically verify if dependency updates do not break something.