### PR TITLE
Fix 'global is not defined' error by providing a polyfill

### DIFF
--- a/frontend/src/polyfills.ts
+++ b/frontend/src/polyfills.ts
@@ -65,6 +65,8 @@
  */
 // (window as any).__Zone_enable_cross_context_check = true;
 
+(window as any).global = window;
+
 /***************************************************************************************************
  * Zone JS is required by default for Angular itself.
  */


### PR DESCRIPTION
Since a recent dependency update the explorer frontend was not showing up any more due to a 'global is not defined' error. deep-equal is the library causing the issue.