### PR TITLE
frontend: Fix network visualization when there are channels without nodes

### DIFF
--- a/frontend/src/app/components/network-graph/network-graph.component.ts
+++ b/frontend/src/app/components/network-graph/network-graph.component.ts
@@ -431,21 +431,26 @@ export class NetworkGraphComponent implements OnInit, OnChanges, OnDestroy, Afte
         simNode.id === value.sourceAddress && simNode.token.address === value.tokenAddress;
       const matchTarget = (simNode: Node) =>
         simNode.id === value.targetAddress && simNode.token.address === value.tokenAddress;
-      const key = this.getNextKey();
 
-      const link: SimulationLink = {
-        source: this.graphData.nodes.find(matchSource),
-        target: this.graphData.nodes.find(matchTarget),
-        sourceAddress: value.sourceAddress,
-        targetAddress: value.targetAddress,
-        status: value.status,
-        capacity: value.capacity,
-        tokenAddress: value.tokenAddress,
-        key: key
-      };
+      const source = this.graphData.nodes.find(matchSource);
+      const target = this.graphData.nodes.find(matchTarget);
 
-      this.keyToDatum[key] = link;
-      this.graphData.links.push(link);
+      if (source && target) {
+        const key = this.getNextKey();
+        const link: SimulationLink = {
+          source: source,
+          target: target,
+          sourceAddress: value.sourceAddress,
+          targetAddress: value.targetAddress,
+          status: value.status,
+          capacity: value.capacity,
+          tokenAddress: value.tokenAddress,
+          key: key
+        };
+
+        this.keyToDatum[key] = link;
+        this.graphData.links.push(link);
+      }
     });
   }
 


### PR DESCRIPTION
closes #235 

Somehow there are channels in the data from the backend which don't have corresponding nodes in the data. This caused the issue #235. This PR simply filters these channels in the network visualization, so it doesn't break.