### PR TITLE
Update docs links to new Raiden documentation

### DIFF
--- a/frontend/src/app/app.component.html
+++ b/frontend/src/app/app.component.html
@@ -9,11 +9,7 @@
       <a href="https://github.com/raiden-network/raiden/" target="_blank" class="navigation-link">
         Github →
       </a>
-      <a
-        href="https://raiden-network.readthedocs.io/en/stable/"
-        target="_blank"
-        class="navigation-link"
-      >
+      <a href="https://docs.raiden.network/" target="_blank" class="navigation-link">
         Docs →
       </a>
     </div>
@@ -45,11 +41,7 @@
     <a href="https://github.com/raiden-network/raiden/" target="_blank" class="navigation-link">
       Github →
     </a>
-    <a
-      href="https://raiden-network.readthedocs.io/en/stable/"
-      target="_blank"
-      class="navigation-link"
-    >
+    <a href="https://docs.raiden.network/" target="_blank" class="navigation-link">
       Docs →
     </a>
   </div>
@@ -73,10 +65,7 @@
       <strong class="bold-footer">Development<br /></strong
       ><a href="https://github.com/raiden-network/raiden/" target="_blank" class="footer-link"
         >Raiden Network Github<br /></a
-      ><a
-        href="https://raiden-network.readthedocs.io/en/stable/"
-        target="_blank"
-        class="footer-link"
+      ><a href="https://docs.raiden.network/" target="_blank" class="footer-link"
         >Raiden Network Docs<br /></a
       ><a
         href="https://explorer.raiden.network/tokens/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"


### PR DESCRIPTION
closes #222 

We still linked to https://raiden-network.readthedocs.io/ on the explorer. This updates the links to use https://docs.raiden.network/