### PR TITLE
Show node online status

### DIFF
--- a/backend/metrics_backend/api/rest.py
+++ b/backend/metrics_backend/api/rest.py
@@ -10,26 +10,28 @@ from gevent.pywsgi import WSGIServer
 from cachetools import TTLCache, cachedmethod
 
 from metrics_backend.metrics_service import MetricsService
+from metrics_backend.presence_service import PresenceService
 from metrics_backend.utils.serialisation import token_network_to_dict, metrics_to_dict
 
 
 class NetworkInfoResource(Resource):
-    def __init__(self, metrics_service: MetricsService) -> None:
+    def __init__(self, metrics_service: MetricsService, presence_service: PresenceService) -> None:
         self.metrics_service = metrics_service
+        self.presence_service = presence_service
         self._cache = TTLCache(maxsize=1, ttl=10)
 
     @cachedmethod(attrgetter('_cache'))
     def get(self):
         overall_metrics = metrics_to_dict(self.metrics_service.state)
         networks = [
-            token_network_to_dict(network)
+            token_network_to_dict(network, self.presence_service.nodes_presence_status)
             for network in self.metrics_service.token_networks.values()
         ]
         return {'overall_metrics': overall_metrics, 'networks': networks}, 200
 
 
 class NetworkInfoAPI:
-    def __init__(self, metrics_service: MetricsService) -> None:
+    def __init__(self, metrics_service: MetricsService, presence_service: PresenceService) -> None:
         self.flask_app = Flask(__name__)
         CORS(self.flask_app)
         self.api = Api(self.flask_app)
@@ -42,6 +44,7 @@ class NetworkInfoAPI:
 
         for endpoint_url, resource, kwargs in resources:
             kwargs['metrics_service'] = metrics_service
+            kwargs['presence_service'] = presence_service
             self.api.add_resource(resource, endpoint_url, resource_class_kwargs=kwargs)
 
     def run(self, port: int = 5002):

--- a/backend/metrics_backend/metrics_cli.py
+++ b/backend/metrics_backend/metrics_cli.py
@@ -178,7 +178,7 @@ def main(
             # re-enable once deployment works
             # gevent.spawn(write_topology_task, service)
 
-            api = NetworkInfoAPI(metrics_service)
+            api = NetworkInfoAPI(metrics_service, presence_service)
             api.run(port=port)
             print(f'Running metrics endpoint at http://localhost:{port}/json')
 

--- a/backend/metrics_backend/metrics_cli.py
+++ b/backend/metrics_backend/metrics_cli.py
@@ -87,16 +87,13 @@ def no_ssl_verification():
     help='Number of block confirmations to wait for'
 )
 @click.option(
-    '--use-production-environment',
-    default=True,
-    type=bool,
-    help='Use the production version of the contracts and transport server'
-)
-@click.option(
-    '--use-demoenv',
-    default=False,
-    type=bool,
-    help='Use the demo environment version of the contracts and transport server'
+    '--environment',
+    default='production',
+    type=click.Choice(['production', 'development', 'demo'], case_sensitive=False),
+    help=(
+        'Change the version of the used contracts and transport server '
+        'by setting the environment to "production" (default), "development" or "demo"'
+    )
 )
 def main(
     eth_rpc,
@@ -104,8 +101,7 @@ def main(
     start_block,
     port,
     confirmations,
-    use_production_environment,
-    use_demoenv
+    environment
 ):
     # setup logging
     logging.basicConfig(
@@ -129,13 +125,9 @@ def main(
         )
         sys.exit()
 
-    if use_production_environment and use_demoenv:
-        log.error('Both production and demo environment are set to true.')
-        sys.exit()
-
-    if use_production_environment:
+    if environment == 'production':
         contracts_version = PRODUCTION_CONTRACTS_VERSION
-    elif use_demoenv:
+    elif environment == 'demo':
         contracts_version = DEMOENV_CONTRACTS_VERSION
     else:
         contracts_version = CONTRACTS_VERSION
@@ -166,12 +158,12 @@ def main(
             )
 
             matrix_server = None
-            if use_demoenv:
+            if environment == 'demo':
                 matrix_server = DEMOENV_MATRIX_SERVER
             presence_service = PresenceService(
                 f'EXPLORER_{web3.eth.chainId}',
                 web3.eth.chainId,
-                use_production_environment,
+                environment == 'production',
                 matrix_server
             )
 

--- a/backend/metrics_backend/presence_service.py
+++ b/backend/metrics_backend/presence_service.py
@@ -79,7 +79,7 @@ class PresenceService(gevent.Greenlet):
 
     def handle_presence_update(self, event: Dict[str, Any], update_id: int) -> None:
         presence = UserPresence(event["content"]["presence"])
-        reachable = USER_PRESENCE_TO_ADDRESS_REACHABILITY[presence] == AddressReachability.REACHABLE
+        reachable = USER_PRESENCE_TO_ADDRESS_REACHABILITY[presence] is AddressReachability.REACHABLE
         node_address = address_from_userid(event["sender"])
         self.nodes_presence_status[node_address] = reachable
 

--- a/backend/metrics_backend/presence_service.py
+++ b/backend/metrics_backend/presence_service.py
@@ -20,8 +20,6 @@ from raiden.utils.cli import get_matrix_servers
 from raiden.utils.signer import LocalSigner, Signer
 from raiden_contracts.utils.type_aliases import ChainID
 
-from metrics_backend.utils import Address
-
 log = logging.getLogger(__name__)
 
 
@@ -50,7 +48,7 @@ class PresenceService(gevent.Greenlet):
 
         self.is_running = gevent.event.Event()
 
-        self.nodes_presence_status: Dict[Address, bool] = {}
+        self.nodes_presence_status: Dict[bytes, bool] = {}
         log.info('Using address %s for matrix login', self.signer.address_hex)
 
     def _run(self):

--- a/backend/metrics_backend/presence_service.py
+++ b/backend/metrics_backend/presence_service.py
@@ -1,0 +1,94 @@
+import hashlib
+import logging
+from typing import Any, Dict
+from urllib.parse import urlparse
+
+import gevent
+from raiden.constants import DISCOVERY_DEFAULT_ROOM, Environment
+from raiden.network.transport.matrix.utils import (
+    USER_PRESENCE_TO_ADDRESS_REACHABILITY,
+    AddressReachability,
+    UserPresence,
+    address_from_userid,
+    join_broadcast_room,
+    login,
+    make_client,
+    make_room_alias
+)
+from raiden.settings import DEFAULT_MATRIX_KNOWN_SERVERS
+from raiden.utils.cli import get_matrix_servers
+from raiden.utils.signer import LocalSigner, Signer
+from raiden_contracts.utils.type_aliases import ChainID
+
+from metrics_backend.utils import Address
+
+log = logging.getLogger(__name__)
+
+
+class PresenceService(gevent.Greenlet):
+    def __init__(
+        self,
+        privkey_seed: str,
+        chain_id: ChainID,
+        production_environment: bool,
+        server: str = None
+    ) -> None:
+        """ Creates a new presence service listening on matrix presence updates
+        in the discovery room
+
+        Args:
+            privkey_seed: Seed for generating a private key for matrix login
+            chain_id: Chain id to listen on presence
+            production_environment: Determines which matrix server to use if none is explicitly set
+            server: Matrix server
+        """
+        super().__init__()
+        self.signer = LocalSigner(hashlib.sha256(privkey_seed.encode()).digest())
+        self.server = server
+        self.chain_id = chain_id
+        self.production_environment = production_environment
+
+        self.is_running = gevent.event.Event()
+
+        self.nodes_presence_status: Dict[Address, bool] = {}
+        log.info('Using address %s for matrix login', self.signer.address_hex)
+
+    def _run(self):
+        available_servers = [self.server]
+        if not self.server:
+            environment_type = Environment.PRODUCTION if self.production_environment else Environment.DEVELOPMENT
+            available_servers_url = DEFAULT_MATRIX_KNOWN_SERVERS[environment_type]
+            available_servers = get_matrix_servers(available_servers_url)
+
+        client = make_client(lambda x: False, lambda x: None, available_servers)
+        self.server = client.api.base_url
+        server_name = urlparse(self.server).netloc
+        login(client=client, signer=self.signer)
+        client.add_presence_listener(self.handle_presence_update)
+        client.start_listener_thread(30_000, 1_000)
+
+        discovery_room_alias = make_room_alias(
+            self.chain_id, DISCOVERY_DEFAULT_ROOM
+        )
+        join_broadcast_room(client, f'#{discovery_room_alias}:{server_name}')
+
+        log.info('Presence monitoring started, server: %s', self.server)
+        self.is_running.wait()
+        client.stop()
+
+    def stop(self):
+        self.is_running.set()
+
+    def handle_presence_update(self, event: Dict[str, Any], update_id: int) -> None:
+        presence = UserPresence(event["content"]["presence"])
+        reachable = USER_PRESENCE_TO_ADDRESS_REACHABILITY[presence] == AddressReachability.REACHABLE
+        node_address = address_from_userid(event["sender"])
+        self.nodes_presence_status[node_address] = reachable
+
+        log.info(
+            'Presence update, server: %s, user_id: %s, presence: %s, update_id: %d',
+            self.server,
+            event["sender"],
+            presence,
+            update_id
+        )

--- a/backend/metrics_backend/utils/serialisation.py
+++ b/backend/metrics_backend/utils/serialisation.py
@@ -1,11 +1,12 @@
-from typing import Dict, List
 from functools import reduce
+from typing import Dict, List
 
+from eth_utils.address import to_canonical_address
 from metrics_backend.model import (
-    TokenNetwork,
     ChannelView,
-    PaymentNetworkMetrics,
     ParticipantsChannels,
+    PaymentNetworkMetrics,
+    TokenNetwork
 )
 from metrics_backend.utils import Address
 
@@ -31,7 +32,10 @@ def _calculate_channels_per_node(
     )
     return num_channels / num_participants if num_participants > 0 else 0
 
-def token_network_to_dict(token_network: TokenNetwork) -> Dict:
+def token_network_to_dict(
+    token_network: TokenNetwork,
+    nodes_presence_status: Dict[bytes, bool]
+) -> Dict:
     """ Returns a JSON serialized version of the token network. """
     num_channels_opened = 0
     num_channels_closed = 0
@@ -62,7 +66,9 @@ def token_network_to_dict(token_network: TokenNetwork) -> Dict:
             num_channels_settled += 1
     
     for address, participants_channels in token_network.participants.items():
+        online_status = nodes_presence_status.get(to_canonical_address(address), False)
         nodes[address] = dict(
+            online=online_status,
             opened=participants_channels.opened,
             closed=participants_channels.closed,
             settled=participants_channels.settled,

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -5,10 +5,11 @@ eth-utils
 
 flask==1.1.2
 flask_restful==0.3.8
-flask-cors==3.0.8
-gevent==1.5.0
-requests==2.23.0
-cachetools==4.1.0
+flask-cors==3.0.9
+gevent==20.6.2
+requests==2.24.0
+cachetools==4.1.1
 
-raiden-contracts==0.37.0
+raiden==1.2.0
+raiden-contracts==0.37.1
 mypy-extensions

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,7 +45,7 @@ services:
     restart: always
     environment:
       - EXPLORER_ETH_RPC=http://geth.ropsten.ethnodes.brainbot.com:8545
-      - EXPLORER_USE_PRODUCTION_ENVIRONMENT=false
+      - EXPLORER_ENVIRONMENT=development
     labels:
       - "traefik.enable=true"
       - "traefik.frontend.rule=Host:ropsten.explorer.raiden.network; Path: /json"
@@ -69,7 +69,7 @@ services:
     restart: always
     environment:
       - EXPLORER_ETH_RPC=http://geth.rinkeby.ethnodes.brainbot.com:8545
-      - EXPLORER_USE_PRODUCTION_ENVIRONMENT=false
+      - EXPLORER_ENVIRONMENT=development
     labels:
       - "traefik.enable=true"
       - "traefik.frontend.rule=Host:rinkeby.explorer.raiden.network; Path: /json"
@@ -93,7 +93,7 @@ services:
     restart: always
     environment:
       - EXPLORER_ETH_RPC=http://parity.goerli.ethnodes.brainbot.com:8545
-      - EXPLORER_USE_PRODUCTION_ENVIRONMENT=false
+      - EXPLORER_ENVIRONMENT=development
     labels:
       - "traefik.enable=true"
       - "traefik.frontend.rule=Host:goerli.explorer.raiden.network; Path: /json"
@@ -117,8 +117,7 @@ services:
     restart: always
     environment:
       - EXPLORER_ETH_RPC=http://parity.goerli.ethnodes.brainbot.com:8545
-      - EXPLORER_USE_PRODUCTION_ENVIRONMENT=false
-      - EXPLORER_USE_DEMOENV=true
+      - EXPLORER_ENVIRONMENT=demo
       - EXPLORER_REGISTRY_ADDRESS="0x5a5CF4A63022F61F1506D1A2398490c2e8dfbb98"
     labels:
       - "traefik.enable=true"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,7 +45,7 @@ services:
     restart: always
     environment:
       - EXPLORER_ETH_RPC=http://geth.ropsten.ethnodes.brainbot.com:8545
-      - EXPLORER_USE_PRODUCTION_CONTRACTS=false
+      - EXPLORER_USE_PRODUCTION_ENVIRONMENT=false
     labels:
       - "traefik.enable=true"
       - "traefik.frontend.rule=Host:ropsten.explorer.raiden.network; Path: /json"
@@ -69,7 +69,7 @@ services:
     restart: always
     environment:
       - EXPLORER_ETH_RPC=http://geth.rinkeby.ethnodes.brainbot.com:8545
-      - EXPLORER_USE_PRODUCTION_CONTRACTS=false
+      - EXPLORER_USE_PRODUCTION_ENVIRONMENT=false
     labels:
       - "traefik.enable=true"
       - "traefik.frontend.rule=Host:rinkeby.explorer.raiden.network; Path: /json"
@@ -93,7 +93,7 @@ services:
     restart: always
     environment:
       - EXPLORER_ETH_RPC=http://parity.goerli.ethnodes.brainbot.com:8545
-      - EXPLORER_USE_PRODUCTION_CONTRACTS=false
+      - EXPLORER_USE_PRODUCTION_ENVIRONMENT=false
     labels:
       - "traefik.enable=true"
       - "traefik.frontend.rule=Host:goerli.explorer.raiden.network; Path: /json"
@@ -117,8 +117,8 @@ services:
     restart: always
     environment:
       - EXPLORER_ETH_RPC=http://parity.goerli.ethnodes.brainbot.com:8545
-      - EXPLORER_USE_PRODUCTION_CONTRACTS=false
-      - EXPLORER_USE_DEMOENV_CONTRACTS=true
+      - EXPLORER_USE_PRODUCTION_ENVIRONMENT=false
+      - EXPLORER_USE_DEMOENV=true
       - EXPLORER_REGISTRY_ADDRESS="0x5a5CF4A63022F61F1506D1A2398490c2e8dfbb98"
     labels:
       - "traefik.enable=true"

--- a/frontend/src/app/models/NMNetwork.ts
+++ b/frontend/src/app/models/NMNetwork.ts
@@ -8,6 +8,7 @@ export interface NMChannel {
 }
 
 export interface NMNode {
+  readonly online: boolean;
   readonly opened: number;
   readonly closed: number;
   readonly settled: number;

--- a/frontend/src/app/models/NetworkGraph.ts
+++ b/frontend/src/app/models/NetworkGraph.ts
@@ -10,6 +10,7 @@ export interface Link {
 
 export interface Node {
   readonly id: string;
+  readonly online: boolean;
   readonly openChannels: number;
   readonly closedChannels: number;
   readonly settledChannels: number;

--- a/frontend/src/app/services/net.metrics/net.metrics.service.ts
+++ b/frontend/src/app/services/net.metrics/net.metrics.service.ts
@@ -111,12 +111,13 @@ export class NetMetricsService {
     const graph: NetworkGraph = { nodes: [], links: [] };
     const token = network.token;
 
-    for (const [address, channels] of Object.entries(network.nodes)) {
+    for (const [address, properties] of Object.entries(network.nodes)) {
       graph.nodes.push({
         id: address,
-        openChannels: channels.opened,
-        closedChannels: channels.closed,
-        settledChannels: channels.settled,
+        online: properties.online,
+        openChannels: properties.opened,
+        closedChannels: properties.closed,
+        settledChannels: properties.settled,
         token: token
       });
     }


### PR DESCRIPTION
Closes #74 

This adds a backend service, that logs into a matrix server a listens on the presence in the discovery room. The presence status is returned by the API in the token network's nodes data. In the network graph of the frontend the nodes are colored green or red depending on the online status.