### PR TITLE
Fix token network animation

### DIFF
--- a/frontend/src/app/components/active-networks-section/active-networks-section.component.html
+++ b/frontend/src/app/components/active-networks-section/active-networks-section.component.html
@@ -64,7 +64,7 @@
     Swipe to view a different token network
   </div>
 
-  <div fxLayout="row" class="carousel" [@flyInOut]="'in'" fxLayoutAlign="center">
+  <div fxLayout="row" class="carousel" fxLayoutAlign="center">
     <div
       fxLayout="column"
       *ngIf="showNavigation"

--- a/frontend/src/app/components/active-networks-section/active-networks-section.component.ts
+++ b/frontend/src/app/components/active-networks-section/active-networks-section.component.ts
@@ -13,7 +13,6 @@ import { FormControl } from '@angular/forms';
 import { flatMap, map, pairwise, startWith } from 'rxjs/operators';
 import { Observable, of, Subscription } from 'rxjs';
 import { Token } from '../../models/NMNetwork';
-import { animate, keyframes, state, style, transition, trigger } from '@angular/animations';
 import { ActiveNetworkSharedService } from '../../services/active-network-shared.service';
 import { ActivatedRoute, Router } from '@angular/router';
 import { RouterAnimations } from './router.animations';
@@ -23,32 +22,7 @@ import { TokenNetworkRoutingService } from '../../services/token-network-routing
   selector: 'app-active-networks-section',
   templateUrl: './active-networks-section.component.html',
   styleUrls: ['./active-networks-section.component.css'],
-  animations: [
-    trigger('flyInOut', [
-      state('in', style({ transform: 'translateX(0)' })),
-      transition('void => *', [
-        animate(
-          300,
-          keyframes([
-            style({ opacity: 0, transform: 'translateX(-100%)', offset: 0 }),
-            style({ opacity: 1, transform: 'translateX(15px)', offset: 0.3 }),
-            style({ opacity: 1, transform: 'translateX(0)', offset: 1.0 })
-          ])
-        )
-      ]),
-      transition('* => void', [
-        animate(
-          300,
-          keyframes([
-            style({ opacity: 1, transform: 'translateX(0)', offset: 0 }),
-            style({ opacity: 1, transform: 'translateX(-15px)', offset: 0.7 }),
-            style({ opacity: 0, transform: 'translateX(100%)', offset: 1.0 })
-          ])
-        )
-      ])
-    ]),
-    RouterAnimations.routerSlide
-  ]
+  animations: [RouterAnimations.routerSlide]
 })
 export class ActiveNetworksSectionComponent implements OnInit, OnChanges, OnDestroy {
   @Input() metrics: RaidenNetworkMetrics;

--- a/frontend/src/app/components/active-networks-section/router.animations.ts
+++ b/frontend/src/app/components/active-networks-section/router.animations.ts
@@ -25,16 +25,16 @@ export class RouterAnimations {
   ]);
 
   static rightOffsets = {
-    enterStart: -100,
-    enterEnd: 0,
-    leaveStart: -100,
-    leaveEnd: 0
+    enterStart: -200,
+    enterEnd: -100,
+    leaveStart: 0,
+    leaveEnd: 100
   };
 
   static leftOffsets = {
-    enterStart: 100,
-    enterEnd: 0,
-    leaveStart: -100,
-    leaveEnd: -200
+    enterStart: 0,
+    enterEnd: -100,
+    leaveStart: 0,
+    leaveEnd: -100
   };
 }


### PR DESCRIPTION
Closes #226 
Fixes the animation of the network info screen to smoothly transition between networks. Also removes an unused animation.