### PR TITLE
Fix error handling in case of an unreachable backend

### DIFF
--- a/frontend/src/app/components/home/home.component.css
+++ b/frontend/src/app/components/home/home.component.css
@@ -1,7 +1,8 @@
 .warning-div {
   background: #ff7f00;
+  color: #ffffff;
   margin: auto;
-  padding: 1rem 8rem;
+  padding: 5% 10%;
   border-radius: 0.2rem;
 }
 
@@ -10,7 +11,8 @@
 }
 
 .warning-wrapper {
-  padding-top: 3em;
+  max-width: 1090px;
+  margin: 0 auto;
 }
 
 .horizontal-padding {

--- a/frontend/src/app/components/home/home.component.html
+++ b/frontend/src/app/components/home/home.component.html
@@ -21,9 +21,9 @@
 
 <ng-template #error>
   <div class="warning-wrapper" [@flyInOut]="'in'">
-    <div class="warning-div" fxLayout="column" fxFlex="0 0 60" *ngIf="messages$ | async as message">
-      <h2 fxLayout="row">{{ message.title }}</h2>
-      <p fxLayout="row">{{ message.description }}</p>
+    <div class="warning-div" fxLayout="column" *ngIf="messages$ | async as message">
+      <h2>{{ message.title }}</h2>
+      <p>{{ message.description }}</p>
     </div>
   </div>
 </ng-template>


### PR DESCRIPTION
closes #208 

We already had an error view, but it was not showing up because of the retry mechanism. This PR makes the error screen showing up when it is not possible to fetch from the backend while still retrying the API call.