### PR TITLE
Show correct color for online nodes when hovering in network graph

### DIFF
--- a/frontend/src/app/components/network-graph/network-graph.component.ts
+++ b/frontend/src/app/components/network-graph/network-graph.component.ts
@@ -946,7 +946,7 @@ export class NetworkGraphComponent implements OnInit, OnChanges, OnDestroy, Afte
           return this.ifNodeElse(selectedNode, node, neighbors, [
             NetworkGraphComponent.HIGHLIGHT_ONLINE_COLOR,
             NetworkGraphComponent.HIGHLIGHT_NEIGHBOR_ONLINE_COLOR,
-            NetworkGraphComponent.DEFAULT_OFFLINE_COLOR
+            NetworkGraphComponent.DEFAULT_ONLINE_COLOR
           ]);
         }
         return this.ifNodeElse(selectedNode, node, neighbors, [


### PR DESCRIPTION
When hovering a node in the network graph there was a little bug that made online nodes to appear as they were offline.