### PR TITLE
 Configure Renovate to use master issue approvals for minor typescript updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,30 +1,44 @@
 {
-  "extends": [
-    "config:base"
-  ],
+  "extends": ["config:base"],
   "python": {
     "enabled": false
   },
   "commitMessagePrefix": "dependencies:",
   "packageRules": [
     {
-      "packagePatterns": [
-        "*"
+      "packagePatterns": ["*"],
+      "updateTypes": [
+        "patch",
+        "pin",
+        "digest",
+        "lockFileMaintenance",
+        "rollback",
+        "bump"
       ],
-      "updateTypes": ["minor", "patch", "pin", "digest", "lockFileMaintenance", "rollback", "bump"],
-      "groupName": "all non-major dependencies",
-      "groupSlug": "all-minor-patch",
-      "schedule": ["after 8am on thursday"],
+      "groupName": "all non-major and non-minor dependencies",
+      "groupSlug": "all-patch",
       "lockFileMaintenance": { "enabled": true }
     },
     {
+      "packagePatterns": ["*"],
+      "excludePackageNames": ["typescript"],
+      "updateTypes": ["minor"],
+      "groupName": "all minor dependencies",
+      "groupSlug": "all-minor"
+    },
+    {
       "updateTypes": ["major"],
+      "masterIssueApproval": true
+    },
+    {
+      "matchPackageNames": ["typescript"],
+      "updateTypes": ["minor"],
       "masterIssueApproval": true
     }
   ],
   "masterIssue": true,
   "labels": ["dependencies"],
-  "schedule": ["after 8am on thursday"],
+  "schedule": ["before 8am on thursday"],
   "prConcurrentLimit": 15,
   "prHourlyLimit": 5,
   "rangeStrategy": "pin",


### PR DESCRIPTION
As in the WebUI we currently have the problem that the CI is failing on dependency updates because Angular does not support the newest minor typescript version. This makes it necessary to approve them in the master issue.