### PR TITLE
Make offline nodes less prominent in network graph

### DIFF
--- a/frontend/src/app/components/network-graph/network-graph.component.ts
+++ b/frontend/src/app/components/network-graph/network-graph.component.ts
@@ -690,62 +690,37 @@ export class NetworkGraphComponent implements OnInit, OnChanges, OnDestroy, Afte
   }
 
   private drawLegend() {
+    if (!this._showAllChannels) {
+      return;
+    }
+
     const legendElementHeight = 12;
     const legendSpacing = 7;
     const legendHeight = legendElementHeight + legendSpacing;
     const offset = 20;
     const legend = this.base.selectAll('.legend');
 
-    const statusScale: d3.ScaleOrdinal<string, any> = d3Scale.scaleOrdinal(
-      ['online', 'offline'],
-      [NetworkGraphComponent.DEFAULT_ONLINE_COLOR, NetworkGraphComponent.DEFAULT_OFFLINE_COLOR]
-    );
-    const statusLegend = legend
-      .data(statusScale.domain())
+    const channelLegend = legend
+      .data(this.channelColors.domain())
       .enter()
       .append('g')
       .classed('legend', true)
       .attr('x', this.width - 100)
       .attr('y', (d, i: number) => i * legendHeight + offset);
 
-    statusLegend
-      .append('circle')
-      .classed('circle', true)
-      .attr('r', 5)
-      .attr('fill', statusScale);
+    channelLegend
+      .append('rect')
+      .classed('rect', true)
+      .attr('width', legendElementHeight)
+      .attr('height', legendElementHeight / 6)
+      .attr('fill', this.channelColors);
 
-    statusLegend
+    channelLegend
       .append('text')
       .classed('text', true)
       .attr('x', 20)
       .attr('y', 5)
       .text((d: string) => d);
-
-    if (this._showAllChannels) {
-      const channelLegendOffset = statusScale.domain().length * legendHeight + 2 * offset;
-
-      const channelLegend = legend
-        .data(this.channelColors.domain())
-        .enter()
-        .append('g')
-        .classed('legend', true)
-        .attr('x', this.width - 100)
-        .attr('y', (d, i: number) => i * legendHeight + channelLegendOffset);
-
-      channelLegend
-        .append('rect')
-        .classed('rect', true)
-        .attr('width', legendElementHeight)
-        .attr('height', legendElementHeight / 6)
-        .attr('fill', this.channelColors);
-
-      channelLegend
-        .append('text')
-        .classed('text', true)
-        .attr('x', 20)
-        .attr('y', 5)
-        .text((d: string) => d);
-    }
   }
 
   private selectLink(link: SimulationLink) {

--- a/frontend/src/app/components/network-graph/network-graph.component.ts
+++ b/frontend/src/app/components/network-graph/network-graph.component.ts
@@ -56,9 +56,9 @@ export class NetworkGraphComponent implements OnInit, OnChanges, OnDestroy, Afte
   private static DEFAULT_ONLINE_COLOR = '#00B35C';
   private static HIGHLIGHT_ONLINE_COLOR = '#00E676';
   private static HIGHLIGHT_NEIGHBOR_ONLINE_COLOR = '#006635';
-  private static DEFAULT_OFFLINE_COLOR = '#CC3B4A';
-  private static HIGHTLIGHT_OFFLINE_COLOR = '#FF495C';
-  private static HIGHLIGHT_NEIGHBOR_OFFLINE_COLOR = '#80252E';
+  private static DEFAULT_OFFLINE_COLOR = '#3D51C3';
+  private static HIGHTLIGHT_OFFLINE_COLOR = '#30D9E6';
+  private static HIGHLIGHT_NEIGHBOR_OFFLINE_COLOR = '#011CB7';
 
   private static OPEN_CHANNEL_COLOR = '#4CAF50';
   private static CLOSED_CHANNEL_COLOR = '#F44336';


### PR DESCRIPTION
Previously in the network graph online nodes were colored green and offline nodes red. As most nodes are offline the red color was a bit too catchy and we decided to not deploy it that way. 

This PR makes the offline nodes blue, so they are less prominent. It also removes the legend for the online status. The Online status is shown textually inside the tooltip.