### PR TITLE
Use demoenv as default goerli deployment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -93,35 +93,11 @@ services:
     restart: always
     environment:
       - EXPLORER_ETH_RPC=http://parity.goerli.ethnodes.brainbot.com:8545
-      - EXPLORER_ENVIRONMENT=development
-    labels:
-      - "traefik.enable=true"
-      - "traefik.frontend.rule=Host:goerli.explorer.raiden.network; Path: /json"
-      
-  frontend-demoenv:
-    build:
-      context: ./frontend
-      args:
-        backend_url: https://demoenv.explorer.raiden.network/json
-        poll_interval: 10000
-        etherscan_base_url: https://goerli.etherscan.io/address/
-        network_name: Goerli
-    restart: always
-    labels:
-      - "traefik.enable=true"
-      - "traefik.frontend.rule=Host:demoenv.explorer.raiden.network"
-
-  backend-demoenv:
-    build:
-      context: ./backend
-    restart: always
-    environment:
-      - EXPLORER_ETH_RPC=http://parity.goerli.ethnodes.brainbot.com:8545
       - EXPLORER_ENVIRONMENT=demo
       - EXPLORER_REGISTRY_ADDRESS="0x5a5CF4A63022F61F1506D1A2398490c2e8dfbb98"
     labels:
       - "traefik.enable=true"
-      - "traefik.frontend.rule=Host:demoenv.explorer.raiden.network; Path: /json"
+      - "traefik.frontend.rule=Host:goerli.explorer.raiden.network; Path: /json"
 
   traefik:
     image: traefik:1.7


### PR DESCRIPTION
We separated our contracts deployment on Goerli in demo and unstable environments (https://github.com/raiden-network/light-client/issues/2514).
As the demo environment is the version users will use this makes http://goerli.explorer.raiden.network using the demo environment and removes http://demoenv.explorer.raiden.network.
If there is the need for an Explorer for our internal unstable environment at a later point in time we can add it again.