### PR TITLE
Remove traefik's dependance on demoenv config and use geth on mainnet

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       context: ./backend
     restart: always
     environment:
-      - EXPLORER_ETH_RPC=http://parity.mainnet.ethnodes.brainbot.com:8545
+      - EXPLORER_ETH_RPC=http://1.geth.mainnet.ethnodes.brainbot.com:8545
       - EXPLORER_CONFIRMATIONS=5
     labels:
       - "traefik.enable=true"
@@ -114,9 +114,7 @@ services:
       - backend-ropsten
       - backend-rinkeby
       - backend-goerli
-      - backend-demoenv
       - frontend
       - frontend-ropsten
       - frontend-rinkeby
       - frontend-goerli
-      - frontend-demoenv


### PR DESCRIPTION
In #266 I forgot to remove the demoenv config in the dependencies of traefik. This also changes the mainnet config to use our geth node as the parity node seems to be not working.