### PR TITLE
backend: Fetch online status of nodes from PFS

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,15 +1,15 @@
-Click==7.0
+Click==8.0.1
 
-web3
+web3==5.19.0
 eth-utils
 
 flask==1.1.2
 flask_restful==0.3.8
-flask-cors==3.0.9
-gevent==20.6.2
-requests==2.24.0
-cachetools==4.1.1
+flask-cors==3.0.10
+gevent==21.1.2
+requests==2.25.1
+cachetools==4.2.2
 
-raiden==1.2.0
-raiden-contracts==0.37.1
+raiden==2.0.0rc0
+raiden-contracts==0.37.5
 mypy-extensions


### PR DESCRIPTION
fixes #276 

This modifies the `PresenceService` to query the new `/online_addresses` endpoint of the PFS. It uses raiden to get a random PFS from the ServiceRegistry. The PFS is queried every 30 seconds.