### PR TITLE
frontend: Fix Try out Raiden link to point to RTD

### DIFF
--- a/frontend/src/app/components/buttons-section/buttons-section.component.html
+++ b/frontend/src/app/components/buttons-section/buttons-section.component.html
@@ -17,7 +17,7 @@
     <a
       mat-flat-button
       color="primary"
-      href="https://docs.raiden.network/quick-start"
+      href="https://raiden-network.readthedocs.io/en/stable/installation/quick-start/"
       target="_blank"
       matTooltip="Get started with Raiden"
       fxLayout="column"


### PR DESCRIPTION
Fixes #286 

As our documentation was completely moved to readthedocs, this updates the "Try out Raiden" link.