### PR TITLE
Replacing Gitter with Discord

### DIFF
--- a/frontend/src/app/app.component.html
+++ b/frontend/src/app/app.component.html
@@ -87,7 +87,7 @@
         target="_blank"
         class="footer-link"
         >Youtube</a
-      ><br /><a href="https://gitter.im/raiden-network/raiden" target="_blank" class="footer-link"
+      ><br /><a href="https://discord.com/invite/nSQDQBq5FC" target="_blank" class="footer-link"
         >Dev chat</a
       ><br />
     </div>


### PR DESCRIPTION
Raiden now have now moved to Discord, this PR replaces Gitter references with a Discord.