### PR TITLE
support legacy ssl provider; unmap traefik ports

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -114,9 +114,6 @@ services:
   traefik:
     image: traefik:1.7
     restart: always
-    ports:
-      - 80:80
-      - 443:443
     volumes:
       - ./config/traefik:/etc/traefik
       - ./data/traefik:/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -114,6 +114,9 @@ services:
   traefik:
     image: traefik:1.7
     restart: always
+    ports:
+      - 80:80
+      - 443:443
     volumes:
       - ./config/traefik:/etc/traefik
       - ./data/traefik:/data

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -28,5 +28,5 @@ RUN cat ./src/assets/config/config.TEMPLATE.json \
     | sed "s#MATOMO_SCRIPT_URL#${matomo_script_url}#" \
     > ./src/assets/config/config.production.json
 
-RUN ng build --prod
+RUN export NODE_OPTIONS=--openssl-legacy-provider ng build
 CMD ["node", "serv-dist/serv.js"]


### PR DESCRIPTION
Fixes #326 

Angular now needs to include an explicit flag to support the legacy openssl provider;
Mapping Traefik port to 443 causes a conflict with docker