### PR TITLE
Fix missing build step

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -28,5 +28,5 @@ RUN cat ./src/assets/config/config.TEMPLATE.json \
     | sed "s#MATOMO_SCRIPT_URL#${matomo_script_url}#" \
     > ./src/assets/config/config.production.json
 
-RUN export NODE_OPTIONS=--openssl-legacy-provider ng build
+RUN ng build --prod
 CMD ["node", "serv-dist/serv.js"]


### PR DESCRIPTION
A recent PR introduced a syntax error in `Dockerfile`, that prevented the frontend image from compiling the project. This change should fix this error.
Fixes #336 -- please see related discusssion attached to the issue.

After merging, the droplet needs to be updated by running the `update.sh` script there.