### PR TITLE
backend: Use exponential backoff when accessing ETH-RPC

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,4 +1,4 @@
-raiden-common == 0.1.4
+raiden-common == 0.1.5
 
 Click
 


### PR DESCRIPTION
Without this, we will get HTTP 429 Errors before finishing the first sync, causing the backend to restart and running into the same error again.